### PR TITLE
feat(nix/addCoverables.nix): allow to configure `uncoverables` paths

### DIFF
--- a/nix/addCoverables.nix
+++ b/nix/addCoverables.nix
@@ -1,5 +1,6 @@
 { lib, haskell, haskellPackages, rsync }:
 { exceptions ? [ ]
+, uncoverables ? [ "test/" ]
 }:
 pkg:
 
@@ -79,7 +80,7 @@ in
   postBuild = (old.postBuild or "") + ''
     mkdir -p $coverables
     ${rsync}/bin/rsync -am \
-      --exclude='test/' \
+      ${lib.escapeShellArgs (lib.map (path: "--exclude=${path}") uncoverables)} \
       --include='*/' \
       --include='*.hs.coverables' \
       --include='*.lhs.coverables' \

--- a/nix/makeCoverageReport.nix
+++ b/nix/makeCoverageReport.nix
@@ -23,6 +23,8 @@ in
 , coverage ? [ ]
   # Modules that will not be source-transformed
 , exceptions ? [ ]
+  # Paths not considered when collecting coverables.
+, uncoverables ? [ "test/" ]
   # If true, the build fails when there are no covered expressions at all.
 , mustCover ? true
   # Minimum coverage percentage (0-100). If set, the build fails when coverage is below this threshold.
@@ -42,7 +44,7 @@ let
     builtins.listToAttrs (builtins.map
       (pname: {
         name = pname;
-        value = addCoverables' { inherit exceptions; } super.${pname};
+        value = addCoverables' { inherit exceptions uncoverables; } super.${pname};
       })
       allCoverables);
   addCoverageOverride = _: super:


### PR DESCRIPTION
Not sure that's the best design/naming/documentation, I just went to the easiest way to enable me to remove `tests/` instead of `test/`.
Let me know if something is amiss, otherwise feel free to modify, merge or discard.

Usage example:
```nix
coverage = pkgs.dekking.makeCoverageReport {
  name = "coverage";
  packages = [
    "GameOfLife"
  ];
  uncoverables = [
    "apps/"
    "tests/"
  ];
};
```